### PR TITLE
Remove originalType from column reader

### DIFF
--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/ParquetReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/ParquetReader.java
@@ -18,7 +18,6 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.PrimitiveColumnIO;
-import org.apache.parquet.schema.OriginalType;
 
 public class ParquetReader implements AutoCloseable {
   private static final int MAX_VECTOR_LENGTH = 1024;
@@ -68,11 +67,7 @@ public class ParquetReader implements AutoCloseable {
         ColumnChunkMetaData metadata = getColumnChunkMetaData(columnDescriptor);
         PegasusPageReader pageReader = new PegasusPageReader(metadata, dataSource, bufferAllocator);
         columnReader =
-            ColumnReaderFactory.createColumnReader(
-                columnDescriptor,
-                OriginalType.INT_32 /*TODO: not used, delete later*/,
-                pageReader,
-                bufferAllocator);
+            ColumnReaderFactory.createColumnReader(columnDescriptor, pageReader, bufferAllocator);
         columnReaders[columnIdx] = columnReader;
       }
 

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/AbstractColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/AbstractColumnReader.java
@@ -27,7 +27,6 @@ import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 /**
  * Decoder to return values from a single column. The column vector type is provided via the generic
@@ -36,7 +35,6 @@ import org.apache.parquet.schema.OriginalType;
  */
 public abstract class AbstractColumnReader<V extends ValueVector> {
   private final ColumnDescriptor desc;
-  private final OriginalType originalType;
   private final PageReader pageReader;
 
   /** If true, the current page is dictionary encoded */
@@ -76,13 +74,8 @@ public abstract class AbstractColumnReader<V extends ValueVector> {
   protected final BufferAllocator allocator;
 
   public AbstractColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
-      throws IOException {
+      ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator) throws IOException {
     this.desc = desc;
-    this.originalType = originalType;
     this.pageReader = pageReader;
     this.maxDefLevel = desc.getMaxDefinitionLevel();
     this.allocator = allocator;

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/BinaryColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/BinaryColumnReader.java
@@ -7,16 +7,11 @@ import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.schema.OriginalType;
 
 public class BinaryColumnReader extends AbstractColumnReader<VarBinaryVector> {
-  public BinaryColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public BinaryColumnReader(ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
-    super(desc, originalType, pageReader, allocator);
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/BooleanColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/BooleanColumnReader.java
@@ -6,16 +6,11 @@ import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class BooleanColumnReader extends AbstractColumnReader<BitVector> {
   public BooleanColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
-      throws IOException {
-    super(desc, originalType, pageReader, allocator);
+      ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator) throws IOException {
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/ColumnReaderFactory.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/ColumnReaderFactory.java
@@ -10,37 +10,33 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class ColumnReaderFactory {
   private ColumnReaderFactory() {}
 
-  public static final AbstractColumnReader createColumnReader(
-      ColumnDescriptor columnDescriptor,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public static AbstractColumnReader<?> createColumnReader(
+      ColumnDescriptor columnDescriptor, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
     switch (columnDescriptor.getPrimitiveType().getPrimitiveTypeName()) {
       case BOOLEAN:
-        return new BooleanColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new BooleanColumnReader(columnDescriptor, pageReader, allocator);
       case INT32:
-        return new IntColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new IntColumnReader(columnDescriptor, pageReader, allocator);
       case INT64:
-        return new LongColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new LongColumnReader(columnDescriptor, pageReader, allocator);
       case FLOAT:
-        return new FloatColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new FloatColumnReader(columnDescriptor, pageReader, allocator);
       case DOUBLE:
-        return new DoubleColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new DoubleColumnReader(columnDescriptor, pageReader, allocator);
       case BINARY:
-        return new BinaryColumnReader(columnDescriptor, originalType, pageReader, allocator);
+        return new BinaryColumnReader(columnDescriptor, pageReader, allocator);
     }
 
     throw new UnsupportedOperationException(
         String.format("Type: %s not yet supported", columnDescriptor));
   }
 
-  public static final ValueVector createValueVector(
+  public static ValueVector createValueVector(
       ColumnDescriptor columnDescriptor, BufferAllocator allocator) {
     String columnName = columnDescriptor.getPath()[columnDescriptor.getPath().length - 1];
     switch (columnDescriptor.getPrimitiveType().getPrimitiveTypeName()) {

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/DoubleColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/DoubleColumnReader.java
@@ -6,16 +6,11 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class DoubleColumnReader extends AbstractColumnReader<Float8Vector> {
-  public DoubleColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public DoubleColumnReader(ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
-    super(desc, originalType, pageReader, allocator);
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/FloatColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/FloatColumnReader.java
@@ -6,16 +6,11 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class FloatColumnReader extends AbstractColumnReader<Float4Vector> {
-  public FloatColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public FloatColumnReader(ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
-    super(desc, originalType, pageReader, allocator);
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/IntColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/IntColumnReader.java
@@ -5,16 +5,11 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class IntColumnReader extends AbstractColumnReader<IntVector> {
-  public IntColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public IntColumnReader(ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
-    super(desc, originalType, pageReader, allocator);
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/LongColumnReader.java
+++ b/pegasus-parquet/src/main/java/com/uber/pegasus/parquet/column/LongColumnReader.java
@@ -6,16 +6,11 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.schema.OriginalType;
 
 public class LongColumnReader extends AbstractColumnReader<BigIntVector> {
-  public LongColumnReader(
-      ColumnDescriptor desc,
-      OriginalType originalType,
-      PageReader pageReader,
-      BufferAllocator allocator)
+  public LongColumnReader(ColumnDescriptor desc, PageReader pageReader, BufferAllocator allocator)
       throws IOException {
-    super(desc, originalType, pageReader, allocator);
+    super(desc, pageReader, allocator);
   }
 
   @Override

--- a/pegasus-parquet/src/test/java/com/uber/pegasus/parquet/column/TestColumnReader.java
+++ b/pegasus-parquet/src/test/java/com/uber/pegasus/parquet/column/TestColumnReader.java
@@ -21,7 +21,6 @@ import org.apache.parquet.column.impl.ColumnWriteStoreV2;
 import org.apache.parquet.column.page.mem.MemPageStore;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.apache.parquet.schema.OriginalType;
 import org.junit.Test;
 
 public class TestColumnReader {
@@ -125,8 +124,7 @@ public class TestColumnReader {
     writeStore.flush();
 
     IntColumnReader reader =
-        new IntColumnReader(
-            desc, OriginalType.INT_32, pageStore.getPageReader(desc), BUFFER_ALLOCATOR);
+        new IntColumnReader(desc, pageStore.getPageReader(desc), BUFFER_ALLOCATOR);
     IntVector out = new IntVector("test", BUFFER_ALLOCATOR);
     out.allocateNew();
     reader.readBatch(data.size(), out);


### PR DESCRIPTION
This removes the unused `originalType` field from `AbstractColumnReader`.